### PR TITLE
hot fix on 404 svg issue on safari

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Sanctuary Computer",
-  "version": "4.2.20",
+  "version": "4.2.21",
   "api_version": 4,
   "default_locale": "en-us",
   "settings": [

--- a/templates/error_page.hbs
+++ b/templates/error_page.hbs
@@ -2,7 +2,7 @@
   <h1 class="sr-only">{{t 'Error - 404'}}</h1>
   <div class="px-margin-mobile sm:px-margin-web min-h-[33.8125rem] sm:min-h-[41.875rem] h-screen pt-nav-h flex flex-col items-center justify-center">
     <div class="w-full flex justify-center">
-      <svg class="max-w-[56.75rem]" viewBox="0 0 908 330" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg class="max-w-[56.75rem] w-full" viewBox="0 0 908 330" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M288.909 29.9062C291.758 29.9062 294.068 27.5977 294.068 24.75C294.068 21.9023 291.758 19.5938 288.909 19.5938C286.059 19.5938 283.75 21.9023 283.75 24.75C283.75 27.5977 286.059 29.9062 288.909 29.9062ZM288.909 33C293.468 33 297.163 29.3064 297.163 24.75C297.163 20.1936 293.468 16.5 288.909 16.5C284.35 16.5 280.654 20.1936 280.654 24.75C280.654 29.3064 284.35 33 288.909 33Z" class="fill-light-accent-1 dark:fill-dark-accent-1"/>
         <path d="M292.005 24.75C292.005 26.4586 290.62 27.8438 288.91 27.8438C287.2 27.8438 285.814 26.4586 285.814 24.75C285.814 23.0414 287.2 21.6562 288.91 21.6562C290.62 21.6562 292.005 23.0414 292.005 24.75Z"  class="fill-light-accent-1 dark:fill-dark-accent-1"/>
         <path fill-rule="evenodd" clip-rule="evenodd" d="M305.419 46.4062C308.268 46.4062 310.578 44.0977 310.578 41.25C310.578 38.4023 308.268 36.0938 305.419 36.0938C302.569 36.0938 300.26 38.4023 300.26 41.25C300.26 44.0977 302.569 46.4062 305.419 46.4062ZM305.419 49.5C309.978 49.5 313.673 45.8064 313.673 41.25C313.673 36.6936 309.978 33 305.419 33C300.86 33 297.164 36.6936 297.164 41.25C297.164 45.8064 300.86 49.5 305.419 49.5Z"  class="fill-light-accent-1 dark:fill-dark-accent-1"/>


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- added `width: 100%` to fix the 404 svg disappearing issue on Safari

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
